### PR TITLE
chore(bump): bump LTS

### DIFF
--- a/graylog.cabal
+++ b/graylog.cabal
@@ -34,6 +34,7 @@ library
                      ,  aeson-casing
                      ,  bytestring
                      ,  network
+                     ,  network-bsd
                      ,  random
                      ,  scientific
                      ,  text

--- a/src/Graylog/Gelf.hs
+++ b/src/Graylog/Gelf.hs
@@ -11,7 +11,6 @@ import           Data.Aeson          (ToJSON (..), Value (..), object, toJSON,
                                       (.=))
 import           Data.HashMap.Strict (HashMap)
 import           Data.Scientific     (Scientific)
-import           Data.Semigroup      ((<>))
 import           Data.Text           (Text)
 import           Data.Time
 import           Data.Typeable

--- a/src/Graylog/UDP.hs
+++ b/src/Graylog/UDP.hs
@@ -8,7 +8,6 @@ module Graylog.UDP
 import           Data.Aeson
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Lazy           as LBS
-import           Data.Monoid
 import           Data.Word
 import           Network.Socket.ByteString.Lazy
 import           System.Random

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-11.5
+resolver: lts-16.31
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Use a more modern LTS and compiler, fixes all ensuing errors / warning / import issues.